### PR TITLE
Added ignoring keyboard safe area

### DIFF
--- a/TabBarSwiftUI/ContentView.swift
+++ b/TabBarSwiftUI/ContentView.swift
@@ -50,6 +50,7 @@ struct ContentView: View {
         .offset(x: ( ( 2 * self.badgePosition) - 1 ) * ( geometry.size.width / ( 2 * self.tabsCount ) ), y: -30)
         .opacity(self.badgeNumber == 0 ? 0 : 1)
       }
+      .ignoresSafeArea(.keyboard)
     }
   }
 }


### PR DESCRIPTION
When a search bar or input area is clicked and the keyboard appears, the badge is pushed. Added .ignoresSafeArea(.keyboard) to mitigate this.